### PR TITLE
blui 3927 update verbiage translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
--   Changed language and translations on verify email registration resend code.
+-   Changed verbiage and translations on verify email registration resend code.
 
 ## v3.7.4 (November 30, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
--   Changed verbiage and translations on verify email registration resend code.
+-   Changed resend email button's text label on the email verification screen.
 
 ## v3.7.4 (November 30, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v3.7.5 (Unreleased)
+
+### Changed
+
+-   Changed language and translations on verify email registration resend code.
+
 ## v3.7.4 (November 30, 2022)
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@brightlayer-ui/react-auth-shared",
     "description": "Re-usable react logic for Authentication and Registration within Eaton applications. For use with @brightlayer-ui/react-native-auth-workflow and @brightlayer-ui/react-auth-workflow.",
-    "version": "3.7.5",
+    "version": "3.7.4",
     "license": "BSD-3-Clause",
     "author": {
         "name": "Brightlayer UI",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@brightlayer-ui/react-auth-shared",
     "description": "Re-usable react logic for Authentication and Registration within Eaton applications. For use with @brightlayer-ui/react-native-auth-workflow and @brightlayer-ui/react-auth-workflow.",
-    "version": "3.7.5",
+    "version": "3.7.5-beta.0",
     "license": "BSD-3-Clause",
     "author": {
         "name": "Brightlayer UI",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@brightlayer-ui/react-auth-shared",
     "description": "Re-usable react logic for Authentication and Registration within Eaton applications. For use with @brightlayer-ui/react-native-auth-workflow and @brightlayer-ui/react-auth-workflow.",
-    "version": "3.7.4",
+    "version": "3.7.5",
     "license": "BSD-3-Clause",
     "author": {
         "name": "Brightlayer UI",

--- a/src/data/translations/chinese.ts
+++ b/src/data/translations/chinese.ts
@@ -79,7 +79,7 @@ const resources: LanguageFile = {
                 MESSAGE:
                     '已向您的邮箱中发送了一封验证邮件。请点击邮件中的链接，或者在此输入邮件中的验证码。验证邮件在30分钟内有效。',
                 RESEND: '重新发送验证邮件',
-                VERIFICATION_CODE_PROMPT: '没有收到验证邮件？',
+                VERIFICATION_CODE_PROMPT: '没有收到电子邮件？',
                 VERIFICATION: '验证码',
             },
         },

--- a/src/data/translations/chinese.ts
+++ b/src/data/translations/chinese.ts
@@ -79,7 +79,7 @@ const resources: LanguageFile = {
                 MESSAGE:
                     '已向您的邮箱中发送了一封验证邮件。请点击邮件中的链接，或者在此输入邮件中的验证码。验证邮件在30分钟内有效。',
                 RESEND: '重新发送验证邮件',
-                VERIFICATION_CODE_PROMPT: '没有收到验证码？',
+                VERIFICATION_CODE_PROMPT: '没有收到验证邮件？',
                 VERIFICATION: '验证码',
             },
         },

--- a/src/data/translations/english.ts
+++ b/src/data/translations/english.ts
@@ -18,7 +18,7 @@ const resources: LanguageFile = {
             CHANGE_LANGUAGE: 'Change Language here!',
             GO_HOME: 'Go to Home',
             GO_TEST: 'Go to Test Page',
-            RESEND: 'Resend',
+            RESEND: 'Send Again',
             UPDATE: 'Update',
             REMEMBER: 'Remember Me',
         },
@@ -80,7 +80,7 @@ const resources: LanguageFile = {
                 MESSAGE:
                     'A verification code has been sent to the email address you provided. Click the link or enter the code below to continue. This code is valid for 30 minutes.',
                 RESEND: 'Resend Verification Email',
-                VERIFICATION_CODE_PROMPT: "Didn't receive a code?",
+                VERIFICATION_CODE_PROMPT: "Didn't receive email?",
                 VERIFICATION: 'Verification Code',
             },
         },

--- a/src/data/translations/english.ts
+++ b/src/data/translations/english.ts
@@ -80,7 +80,7 @@ const resources: LanguageFile = {
                 MESSAGE:
                     'A verification code has been sent to the email address you provided. Click the link or enter the code below to continue. This code is valid for 30 minutes.',
                 RESEND: 'Resend Verification Email',
-                VERIFICATION_CODE_PROMPT: "Didn't receive email?",
+                VERIFICATION_CODE_PROMPT: "Didn't receive an email?",
                 VERIFICATION: 'Verification Code',
             },
         },

--- a/src/data/translations/french.ts
+++ b/src/data/translations/french.ts
@@ -18,7 +18,7 @@ const resources: LanguageFile = {
             CHANGE_LANGUAGE: 'Changer de langue ici!',
             GO_HOME: 'Aller à la maison',
             GO_TEST: 'Aller à la page de test',
-            RESEND: 'Renvoyer',
+            RESEND: 'Envoyer à nouveau',
             UPDATE: 'Mise à jour',
             REMEMBER: 'Souvenez-vous de moi',
         },
@@ -79,7 +79,7 @@ const resources: LanguageFile = {
             VERIFY_EMAIL: {
                 MESSAGE: `Un code de vérification a été envoyé à l'adresse e-mail que vous avez fournie. Cliquez sur le lien ou entrez le code ci-dessous pour continuer. Ce code est valable 30 minutes.`,
                 RESEND: `Renvoyer l'e-mail de vérification`,
-                VERIFICATION_CODE_PROMPT: "Vous n'avez pas reçu de code ?",
+                VERIFICATION_CODE_PROMPT: "Vous n'avez pas reçu d'e-mail ?",
                 VERIFICATION: 'Code de vérification',
             },
         },

--- a/src/data/translations/french.ts
+++ b/src/data/translations/french.ts
@@ -79,7 +79,7 @@ const resources: LanguageFile = {
             VERIFY_EMAIL: {
                 MESSAGE: `Un code de vérification a été envoyé à l'adresse e-mail que vous avez fournie. Cliquez sur le lien ou entrez le code ci-dessous pour continuer. Ce code est valable 30 minutes.`,
                 RESEND: `Renvoyer l'e-mail de vérification`,
-                VERIFICATION_CODE_PROMPT: "Vous n'avez pas reçu d'e-mail?",
+                VERIFICATION_CODE_PROMPT: "Vous n'avez pas reçu d'e-mail ?",
                 VERIFICATION: 'Code de vérification',
             },
         },

--- a/src/data/translations/french.ts
+++ b/src/data/translations/french.ts
@@ -79,7 +79,7 @@ const resources: LanguageFile = {
             VERIFY_EMAIL: {
                 MESSAGE: `Un code de vérification a été envoyé à l'adresse e-mail que vous avez fournie. Cliquez sur le lien ou entrez le code ci-dessous pour continuer. Ce code est valable 30 minutes.`,
                 RESEND: `Renvoyer l'e-mail de vérification`,
-                VERIFICATION_CODE_PROMPT: "Vous n'avez pas reçu d'e-mail ?",
+                VERIFICATION_CODE_PROMPT: "Vous n'avez pas reçu d'e-mail?",
                 VERIFICATION: 'Code de vérification',
             },
         },

--- a/src/data/translations/portuguese.ts
+++ b/src/data/translations/portuguese.ts
@@ -81,7 +81,7 @@ const resources: LanguageFile = {
                 MESSAGE:
                     'Foi enviado um código de verificação para o e-mail que indicou. Clique no link ou preencha o campo com o código para continuar. Este código é válido durante 30 minutos.',
                 RESEND: 'Reenviar e-mail de verificação',
-                VERIFICATION_CODE_PROMPT: 'Não recebi um e-mail?',
+                VERIFICATION_CODE_PROMPT: 'Não recebeu um e-mail?',
                 VERIFICATION: 'Código de verificação',
             },
         },

--- a/src/data/translations/portuguese.ts
+++ b/src/data/translations/portuguese.ts
@@ -18,7 +18,7 @@ const resources: LanguageFile = {
             CHANGE_LANGUAGE: 'Alterar idioma aqui!',
             GO_HOME: 'Ir para a Página Principal',
             GO_TEST: 'Ir para a Página de testes',
-            RESEND: 'Reenviar',
+            RESEND: 'Envie novamente',
             UPDATE: 'Atualizar',
             REMEMBER: 'Lembrar-me',
         },
@@ -81,7 +81,7 @@ const resources: LanguageFile = {
                 MESSAGE:
                     'Foi enviado um código de verificação para o e-mail que indicou. Clique no link ou preencha o campo com o código para continuar. Este código é válido durante 30 minutos.',
                 RESEND: 'Reenviar e-mail de verificação',
-                VERIFICATION_CODE_PROMPT: 'Não recebeu um código?',
+                VERIFICATION_CODE_PROMPT: 'Não recebi um e-mail?',
                 VERIFICATION: 'Código de verificação',
             },
         },

--- a/src/data/translations/spanish.ts
+++ b/src/data/translations/spanish.ts
@@ -79,7 +79,7 @@ const resources: LanguageFile = {
             VERIFY_EMAIL: {
                 MESSAGE: `Se ha enviado un código de verificación a la dirección de correo electrónico que proporcionó. Haga clic en el enlace o ingrese el código abajo para continuar. Este código es válido por 30 minutos.`,
                 RESEND: 'Reenviar correo electrónico de verificación',
-                VERIFICATION_CODE_PROMPT: '¿No recibiste el correo electrónico?',
+                VERIFICATION_CODE_PROMPT: '¿No recibiste un correo electrónico?',
                 VERIFICATION: 'Código de verificación',
             },
         },

--- a/src/data/translations/spanish.ts
+++ b/src/data/translations/spanish.ts
@@ -18,7 +18,7 @@ const resources: LanguageFile = {
             CHANGE_LANGUAGE: '¡Cambie el idioma aquí!',
             GO_HOME: 'Ir a casa',
             GO_TEST: 'Ir a la página de prueba',
-            RESEND: 'Reenviar',
+            RESEND: 'Envie novamente',
             UPDATE: 'Actualizar',
             REMEMBER: 'Recordar contraseña',
         },
@@ -79,7 +79,7 @@ const resources: LanguageFile = {
             VERIFY_EMAIL: {
                 MESSAGE: `Se ha enviado un código de verificación a la dirección de correo electrónico que proporcionó. Haga clic en el enlace o ingrese el código abajo para continuar. Este código es válido por 30 minutos.`,
                 RESEND: 'Reenviar correo electrónico de verificación',
-                VERIFICATION_CODE_PROMPT: '¿No recibiste un código?',
+                VERIFICATION_CODE_PROMPT: 'no recibi un correo electronico?',
                 VERIFICATION: 'Código de verificación',
             },
         },

--- a/src/data/translations/spanish.ts
+++ b/src/data/translations/spanish.ts
@@ -18,7 +18,7 @@ const resources: LanguageFile = {
             CHANGE_LANGUAGE: '¡Cambie el idioma aquí!',
             GO_HOME: 'Ir a casa',
             GO_TEST: 'Ir a la página de prueba',
-            RESEND: 'Envie novamente',
+            RESEND: 'Enviar de nuevo',
             UPDATE: 'Actualizar',
             REMEMBER: 'Recordar contraseña',
         },
@@ -79,7 +79,7 @@ const resources: LanguageFile = {
             VERIFY_EMAIL: {
                 MESSAGE: `Se ha enviado un código de verificación a la dirección de correo electrónico que proporcionó. Haga clic en el enlace o ingrese el código abajo para continuar. Este código es válido por 30 minutos.`,
                 RESEND: 'Reenviar correo electrónico de verificación',
-                VERIFICATION_CODE_PROMPT: 'no recibi un correo electronico?',
+                VERIFICATION_CODE_PROMPT: '¿No recibiste el correo electrónico?',
                 VERIFICATION: 'Código de verificación',
             },
         },


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes BLUI-3927.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Update VERIFICATION_CODE_PROMPT & ACTIONS.RESEND verbiage
-
-

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

-

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- run workflow branch https://github.com/etn-ccis/blui-react-workflows/pull/241 or dev if merged
- cd shared-auth and checkout feature/blui-3927-update-verbiage-prompts
- yarn start:example

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
