### PR TITLE
HOTFIX: Allow hiding the Login Form in Login screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Ability to hide the CreatePassword screen
 
+### Added
+
+-   Ability to hide the Login form in login screen
+
 ### Changed
 
 -   Changed resend email button's text label on the email verification screen.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 -   Ability to hide the CreatePassword screen
-
-### Added
-
--   Ability to hide the Login form in login screen
+-   Ability to hide the login form in the Login screen.
 
 ### Changed
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -93,6 +93,9 @@ import { AuthUIContextProvider } from '@brightlayer-ui/react-native-auth-workflo
 -   **showSelfRegistration**: _`boolean`_
     -   When true, shows the Create Account button to allow for self registration.
     -   Default: true
+-   **showLoginForm**: (optional) _`boolean`_
+    -   When true, the Login Form will be part of Login Screen
+    -   Default: true
 
 ### SecurityContextProvider
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -94,7 +94,7 @@ import { AuthUIContextProvider } from '@brightlayer-ui/react-native-auth-workflo
     -   When true, shows the Create Account button to allow for self registration.
     -   Default: true
 -   **showLoginForm**: (optional) _`boolean`_
-    -   When true, the login form will be part of the Login screen.
+    -   When true, the login form will be part of the Login screen to allow for login form.
     -   Default: true
 
 ### SecurityContextProvider

--- a/docs/API.md
+++ b/docs/API.md
@@ -94,7 +94,7 @@ import { AuthUIContextProvider } from '@brightlayer-ui/react-native-auth-workflo
     -   When true, shows the Create Account button to allow for self registration.
     -   Default: true
 -   **showLoginForm**: (optional) _`boolean`_
-    -   When true, the Login Form will be part of Login Screen
+    -   When true, the login form will be part of the Login screen.
     -   Default: true
 
 ### SecurityContextProvider

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@brightlayer-ui/react-auth-shared",
     "description": "Re-usable react logic for Authentication and Registration within Eaton applications. For use with @brightlayer-ui/react-native-auth-workflow and @brightlayer-ui/react-auth-workflow.",
-    "version": "4.0.0-alpha.0",
+    "version": "4.0.0-alpha.1",
     "license": "BSD-3-Clause",
     "author": {
         "name": "Brightlayer UI",

--- a/src/contexts/AuthUIContextProvider/provider.tsx
+++ b/src/contexts/AuthUIContextProvider/provider.tsx
@@ -41,6 +41,7 @@ export const AuthUIContextProvider: React.FC<React.PropsWithChildren<AuthUIConte
             accountAlreadyExistsScreen: props.accountAlreadyExistsScreen,
             registrationConfig: props.registrationConfig,
             disablePagerAnimation: props.disablePagerAnimation,
+            showLoginForm: props.showLoginForm,
         };
 
         return propsForContext;
@@ -72,6 +73,7 @@ export const AuthUIContextProvider: React.FC<React.PropsWithChildren<AuthUIConte
         props.showCybersecurityBadge,
         props.showSelfRegistration,
         props.registrationConfig,
+        props.showLoginForm,
     ]);
 
     return <AuthUIContext.Provider value={memoizedProps}>{props.children}</AuthUIContext.Provider>;

--- a/src/contexts/AuthUIContextProvider/types.ts
+++ b/src/contexts/AuthUIContextProvider/types.ts
@@ -207,7 +207,7 @@ type AuthUIContextProviderProps = {
      */
     disablePagerAnimation?: boolean;
     /**
-     * When true, the Login Form will be part of Login Screen
+     * When true, the login form will be part of the Login screen.
      *
      * Default: true
      */

--- a/src/contexts/AuthUIContextProvider/types.ts
+++ b/src/contexts/AuthUIContextProvider/types.ts
@@ -206,6 +206,12 @@ type AuthUIContextProviderProps = {
      * Default: false
      */
     disablePagerAnimation?: boolean;
+    /**
+     * When true, the Login Form will be part of Login Screen
+     *
+     * Default: true
+     */
+    showLoginForm?: boolean;
 };
 
 export type {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

- Remove the login form in login screen if the Auth configuration has disabled it

#### To Test:

- clone the workflow repo
- cd login-workflow
- yarn initialize
- cd shared-auth
- git checkout feature/hide-create-password
- cd ..
- yarn start:example
